### PR TITLE
Add separators between character colour pickers

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -1468,7 +1468,7 @@ export function defineBlocks() {
         variableNamePrefix + nextVariableIndexes[variableNamePrefix];
       this.jsonInit({
         message0: `set %1 to %2 scale: %3 x: %4 y: %5 z: %6
-				Hair: %7 Skin: %8 Eyes: %9 T-Shirt: %10 Shorts: %11 Detail: %12`,
+				Hair: %7 |  Skin: %8 |  Eyes: %9 |  T-Shirt: %10 |  Shorts: %11 |  Detail: %12`,
         args0: [
           {
             type: "field_variable",


### PR DESCRIPTION
We wanted to make it clearer which colour the text related to on the character colour picker. I tried a few different things to increase the spacing (adding white space, trying to target it with CSS) but the only thing that had an effect is adding pipe separators.

Suspect this may just be a limitation with Blockly.

**Note**
Not sure this is actually an improvement, as looks different to the rest of the UI.

Before: 

![Screenshot 2025-06-06 at 15 56 48](https://github.com/user-attachments/assets/2149692c-7ef4-468e-adf5-77df55b53005)

After: 

![Screenshot 2025-06-06 at 16 30 52](https://github.com/user-attachments/assets/a411501c-9c61-47ab-841f-1bb0d1e663f7)

Up to you if you'd like to go ahead or abandon!