### PR TITLE
fix(#14): live-update sky color when input is a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.vscode/
 .replit
 replit.nix
 .breakpoints

--- a/ui/designview.js
+++ b/ui/designview.js
@@ -276,6 +276,22 @@ export function updateMeshFromBlock(mesh, block, changeEvent) {
   }
 
   if (block.type === "set_sky_color") {
+    let isColorList = false;
+    let colorList = [];
+
+    for (let child of block.childBlocks_) {
+      if (child.type === "lists_create_with") {
+        isColorList = true;
+        for (let input of child.inputList) {
+          colorList.push(input.connection.targetBlock().getFieldValue("COLOR"));
+        };
+      };
+    };
+
+    if (isColorList) {
+      color = colorList;
+    };
+
     flock.setSky(color);
     return;
   }


### PR DESCRIPTION
Ref: https://github.com/flipcomputing/flock/issues/14

Hello there!

This is as compact and as least invasive yet readable a solution I could come up with. Hoping my code is itself self explanatory, here's a broken-down walkthrough of my approach:

After several tests, I caught the problem to be that `updateMeshFromBlock()` was reading only whether the block type  is `"set_sky_color"` or not, but it wasn't considering what type of input `"set_sky_color"` was taking (it just assumed it to be its default type: `"color"`, or `"colour"`, if I remember correctly).

Original `ui\designview.jsl`:
```
  <... more code in file>
  if (block.type === "set_sky_color") {
    flock.setSky(color);
    return;
  }
  <more code in file ...>
```

**What does my implementation do?**

It initializes a boolean evaluator (defaulted as false) to determine, upon call of `updateMeshFromBlock`, if the input taken by `"set_sky_color"` is a list or not, and an empty array `colorList` to be populated whenever the former is set to true.

Then it loops through the children of `"set_sky_color"` to determine if its input is indeed a list (type: `"lists_create_with"`), and if that's the case: **1)** it pushes said list's values into `colorList`, and **2)** intercepts `color` and assigns it `colorList` so it's accordingly updated when passed as argument in `flock.seSky()` a couple lines later. If there's no `"lists_create_with"` as input for `"set_sky_color"`, `color` remains untouched.

Edit `ui\designview.jsl`:
```
  <...more code in file>
  if (block.type === "set_sky_color") {
    let isColorList = false;
    let colorList = [];

    for (let child of block.childBlocks_) {
      if (child.type === "lists_create_with") {
        isColorList = true;
        for (let input of child.inputList) {
          colorList.push(input.connection.targetBlock().getFieldValue("COLOR"));
        };
      };
    };

    if (isColorList) {
      color = colorList;
    };

    flock.setSky(color);
    return;
  }
  <more code in file...>
```

**Important considerations:**
- Three or more colors in the list won't create a gradient, it didn't do it upon "run code" in the original version either, per my recolection. I don't know if this is by design or not, but that's outside this issue's scope I reckon.
- I didn't want to mess with your codebase style with my Prettier, so I included a `.vscode/settings.json` to bypass my _format on save_ set-up, however I git-ignored it so it doesn't override any settings you folks have in your workspaces either.

Please test as needed and let me know your thoughts.

I hope this is helpful!