### PR TITLE
Fix shape menu z-index stacking

### DIFF
--- a/style.css
+++ b/style.css
@@ -251,6 +251,7 @@ path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
 #shape-menu {
   position: relative;
   display: inline-block;
+  z-index: 80;
 }
 
 #shapes-dropdown {


### PR DESCRIPTION
The toolbox was appearing in front of the shape menu, blocking access to some shapes on a smaller screen size.

The toolbox has a z-index of 70, so I've given the shape menu a z-index of 80 to ensure that it appears in front.

Fixes #12

----
Notes: 

I wasn't sure where/how to test this, so didn't as it's a small change, but let me know if I've missed something.
I've put the new index at 80 as that seemed reasonable, but if you have a z-index system in place that this doesn't work with, let me know!

Before

![toolbox_overlap](https://github.com/user-attachments/assets/a266a00a-cf6e-49a5-bdab-6a8e57707d13)


After

![shape_menu_overlap](https://github.com/user-attachments/assets/38941674-41bb-45d2-828b-d1b165b6bb39)
