### PR TITLE
Prevent say text planes from inheriting mesh material changes

### DIFF
--- a/api/material.js
+++ b/api/material.js
@@ -284,7 +284,14 @@ export const flockMaterial = {
     // Map to keep track of materials and their assigned colours and indices
     const materialToColorMap = new Map();
 
+    const isSayTextPlane = (part) =>
+      part?.name === "textPlane" || part?.metadata?.isSayTextPlane;
+
     function applyColorInOrder(part) {
+      if (isSayTextPlane(part)) {
+        return;
+      }
+
       if (part.material) {
         // Check if the material is already processed
         if (!materialToColorMap.has(part.material)) {
@@ -462,7 +469,12 @@ export const flockMaterial = {
     material.backFaceCulling = false;
 
     // Assign the material to the mesh and its descendants
-    const allMeshes = [mesh].concat(mesh.getDescendants());
+    const allMeshes = [mesh]
+      .concat(mesh.getDescendants())
+      .filter(
+        (part) =>
+          part.name !== "textPlane" && !part.metadata?.isSayTextPlane,
+      );
     allMeshes.forEach((part) => {
       part.material = material;
     });
@@ -475,7 +487,12 @@ export const flockMaterial = {
   },
   setMaterial(meshName, materials) {
     return flock.whenModelReady(meshName, (mesh) => {
-      const allMeshes = [mesh].concat(mesh.getDescendants());
+      const allMeshes = [mesh]
+        .concat(mesh.getDescendants())
+        .filter(
+          (part) =>
+            part.name !== "textPlane" && !part.metadata?.isSayTextPlane,
+        );
       const validMeshes = allMeshes.filter(
         (part) => part instanceof flock.BABYLON.Mesh,
       );

--- a/api/ui.js
+++ b/api/ui.js
@@ -439,6 +439,10 @@ export const flockUI = {
             flock.scene,
           );
           plane.name = "textPlane";
+          plane.metadata = {
+            ...(plane.metadata || {}),
+            isSayTextPlane: true,
+          };
           plane.parent = targetMesh;
           plane.alpha = 1;
           plane.checkCollisions = false;


### PR DESCRIPTION
## Summary
- mark speech-bubble planes created by `flock.say` with `metadata.isSayTextPlane`
- exclude say text planes from `changeColorMesh` traversal so text bubble visuals are not recolored with parent meshes
- exclude say text planes from `changeMaterialMesh` and `setMaterial` descendant material assignment

## Why
Changing a mesh color/material was also changing the speech bubble plane material because `textPlane` is a descendant. This keeps mesh styling operations scoped to the mesh itself and preserves speech bubble appearance.

## Validation
- Performed static inspection of material and UI code paths to ensure say text planes are tagged and filtered in all key material-application methods.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdcac79648326808b51f6fa973ae8)